### PR TITLE
Fix documentation of component props in readme.md

### DIFF
--- a/packages/next-tweet/readme.md
+++ b/packages/next-tweet/readme.md
@@ -51,7 +51,7 @@ export default function Page({ params }: Props) {
 
 `NextTweet` accepts the following props:
 
-- `params.tweet` - `string`: the tweet ID. For example in `https://twitter.com/chibicode/status/1629307668568633344` the tweet ID is `1629307668568633344`.
+- `id` - `string`: the tweet ID. For example in `https://twitter.com/chibicode/status/1629307668568633344` the tweet ID is `1629307668568633344`.
 - `priority` - `boolean`: sets the [`priority` prop](https://nextjs.org/docs/basic-features/image-optimization#priority) in the Tweet's images. Only enable this if the tweet is visible above the fold. Defaults to `false`.
 - `notFoundOnError` - `boolean`: if `true`, the component will show a not found message if the tweet fails to load (invalid id, no longer exists, account went private, etc). Otherwise, it will throw an error. Defaults to `false`.
 


### PR DESCRIPTION
The component prop is `id`, not `params.tweet`.