### PR TITLE
Make video play button keyboard accessible

### DIFF
--- a/packages/next-tweet/src/tweet-media-video.module.css
+++ b/packages/next-tweet/src/tweet-media-video.module.css
@@ -12,7 +12,8 @@
   border-radius: 9999px;
   cursor: pointer;
 }
-.videoButton:hover {
+.videoButton:hover,
+.videoButton:focus-visible {
   background-color: rgb(26, 140, 216);
 }
 .videoButtonIcon {

--- a/packages/next-tweet/src/tweet-media-video.tsx
+++ b/packages/next-tweet/src/tweet-media-video.tsx
@@ -36,9 +36,8 @@ export const TweetMediaVideo = ({ media }: Props) => {
       </video>
 
       {playButton && (
-        <div
+        <button
           className={s.videoButton}
-          role="button"
           aria-label="View video on Twitter"
           onClick={(e) => {
             const video = e.currentTarget.previousSibling as HTMLMediaElement
@@ -57,7 +56,7 @@ export const TweetMediaVideo = ({ media }: Props) => {
               <path d="M21 12L4 2v20l17-10z"></path>
             </g>
           </svg>
-        </div>
+        </button>
       )}
     </>
   )

--- a/packages/next-tweet/src/tweet-media-video.tsx
+++ b/packages/next-tweet/src/tweet-media-video.tsx
@@ -37,6 +37,7 @@ export const TweetMediaVideo = ({ media }: Props) => {
 
       {playButton && (
         <button
+          type="button"
           className={s.videoButton}
           aria-label="View video on Twitter"
           onClick={(e) => {


### PR DESCRIPTION
Using `role="button"` without the accompanying event handlers that a native `button` provides creates an experience that is not accessible to keyboard users. [MDN - ARIA: button role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/button_role#sect1)

Unless there is a specific reason not to, this should just be a `button`. This changes that, and adds  `:focus-visible` css for additional visual indication.