### PR TITLE
Add support for stock symbols in tweet body

### DIFF
--- a/packages/next-tweet/src/api/types/entities.ts
+++ b/packages/next-tweet/src/api/types/entities.ts
@@ -26,10 +26,15 @@ export interface UrlEntity {
   url: string
 }
 
+export interface SymbolEntity {
+  indices: Indices
+  text: string
+}
+
 export interface TweetEntities {
   hashtags: HashtagEntity[]
   urls: UrlEntity[]
   user_mentions: UserMentionEntity[]
-  symbols: { text: string }[]
+  symbols: SymbolEntity[]
   media?: MediaEntity[]
 }

--- a/packages/next-tweet/src/tweet-body.tsx
+++ b/packages/next-tweet/src/tweet-body.tsx
@@ -5,8 +5,9 @@ import type {
   UserMentionEntity,
   UrlEntity,
   MediaEntity,
+  SymbolEntity,
 } from './api'
-import { getHashtagUrl, getUserUrl } from './utils'
+import { getHashtagUrl, getUserUrl, getSymbolUrl } from './utils'
 import { TweetLink } from './tweet-link'
 import s from './tweet-body.module.css'
 
@@ -21,10 +22,11 @@ type Entity =
   | (UserMentionEntity & { type: 'mention' })
   | (UrlEntity & { type: 'url' })
   | (MediaEntity & { type: 'media' })
+  | (SymbolEntity & { type: 'symbol' })
 
 function addEntities(
   result: Entity[],
-  entities: (HashtagEntity | UserMentionEntity | MediaEntity)[],
+  entities: (HashtagEntity | UserMentionEntity | MediaEntity | SymbolEntity)[],
   type: Entity['type']
 ) {
   for (const entity of entities) {
@@ -63,6 +65,7 @@ function getEntities(tweet: Tweet) {
   addEntities(result, tweet.entities.hashtags, 'hashtag')
   addEntities(result, tweet.entities.user_mentions, 'mention')
   addEntities(result, tweet.entities.urls, 'url')
+  addEntities(result, tweet.entities.symbols, 'symbol')
   if (tweet.entities.media) {
     addEntities(result, tweet.entities.media, 'media')
   }
@@ -95,6 +98,12 @@ export const TweetBody = ({ tweet }: { tweet: Tweet }) => {
             return (
               <TweetLink key={i} href={item.expanded_url}>
                 {item.display_url}
+              </TweetLink>
+            )
+          case 'symbol':
+            return (
+              <TweetLink key={i} href={getSymbolUrl(item)}>
+                {text}
               </TweetLink>
             )
           case 'media':

--- a/packages/next-tweet/src/utils.ts
+++ b/packages/next-tweet/src/utils.ts
@@ -1,4 +1,4 @@
-import type { Tweet, MediaDetails, HashtagEntity } from './api'
+import type { Tweet, MediaDetails, HashtagEntity, SymbolEntity } from './api'
 
 export const getUserUrl = (usernameOrTweet: string | Tweet) =>
   `https://twitter.com/${
@@ -21,6 +21,9 @@ export const getFollowUrl = (tweet: Tweet) =>
 
 export const getHashtagUrl = (hashtag: HashtagEntity) =>
   `https://twitter.com/hashtag/${hashtag.text}`
+
+export const getSymbolUrl = (symbol: SymbolEntity) =>
+  `https://twitter.com/search?q=%24${symbol.text}`
 
 export const getInReplyToUrl = (tweet: Tweet) =>
   `https://twitter.com/${tweet.in_reply_to_screen_name}/status/${tweet.in_reply_to_status_id_str}`


### PR DESCRIPTION
Noticed it was not linking stock symbols in the tweet body. This links them up to a search query URL to match Twitter functionality.