### PR TITLE
Add accessible text to icon only link in `TweetInfo`

### DIFF
--- a/packages/next-tweet/src/tweet-info.tsx
+++ b/packages/next-tweet/src/tweet-info.tsx
@@ -11,6 +11,7 @@ export const TweetInfo = ({ tweet }: { tweet: Tweet }) => {
         href="https://help.twitter.com/en/twitter-for-websites-ads-info-and-privacy"
         target="_blank"
         rel="noopener noreferrer"
+        aria-label="Twitter for Websites, Ads Information and Privacy"
       >
         <svg viewBox="0 0 24 24" aria-hidden="true" className={s.infoIcon}>
           <g>


### PR DESCRIPTION
This `<a>` contains only an `<svg>` and no accessible text, which makes it unusable to screen readers. This adds text via an `aria-label` attribute.

In lieu of the `aria-` attribute, I would normally resolve this kind of thing with an `sr-only` or `visually-hidden` type of utility class and related CSS to allow the content inside the `<a>` to exist, but I'm not seeing any existing pattern/class like that in this project, so the `aria-label` should suffice.