### PR TITLE
Honor prefers-reduce-motion when animating the skeleton

### DIFF
--- a/packages/next-tweet/src/skeleton.module.css
+++ b/packages/next-tweet/src/skeleton.module.css
@@ -7,6 +7,12 @@
   animation: loading 8s ease-in-out infinite;
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .skeleton {
+    animation: none;
+  }
+}
+
 @keyframes loading {
   0% {
     background-position: 200% 0;

--- a/packages/next-tweet/src/skeleton.module.css
+++ b/packages/next-tweet/src/skeleton.module.css
@@ -10,6 +10,7 @@
 @media (prefers-reduced-motion: reduce) {
   .skeleton {
     animation: none;
+    background-position: 200% 0;
   }
 }
 


### PR DESCRIPTION
As an accessibility enhancement, to better serve users who may have set their OS to reduce the amount of motion on screen, we should check for that and disable the Skeleton's animation.