### PR TITLE
Decode HTML entities in body

### DIFF
--- a/packages/next-tweet/src/tweet-body.tsx
+++ b/packages/next-tweet/src/tweet-body.tsx
@@ -102,7 +102,7 @@ export const TweetBody = ({ tweet }: { tweet: Tweet }) => {
             // that do match `display_text_range` so for those cases we ignore the content.
             return undefined
           default:
-            return <span key={i}>{text}</span>
+            return <span key={i} dangerouslySetInnerHTML={{ __html: text }} />
         }
       })}
     </p>


### PR DESCRIPTION
Fixes #29 

Most of the details are over on the issue (#29), but the gist is that the API responds with encoded HTML entities. In order to properly render those, we need to use `dangerouslySetInnerHTML` on the containing `<span>`.