### PR TITLE
Make ts-ignore comments no longer necessary

### DIFF
--- a/apps/test-app/app/light/[tweet]/page.tsx
+++ b/apps/test-app/app/light/[tweet]/page.tsx
@@ -22,7 +22,6 @@ export async function generateMetadata({ params }: Props) {
   return { title: `${text}${username}` }
 }
 
-export default async function Page({ params }: Props) {
-  // @ts-ignore: Async components are valid in the app directory
+export default function Page({ params }: Props) {
   return <NextTweet id={params.tweet} priority />
 }

--- a/apps/test-app/app/light/mdx/page.tsx
+++ b/apps/test-app/app/light/mdx/page.tsx
@@ -1,6 +1,5 @@
 import Post from './post.mdx'
 
-export default async function Page() {
-  // @ts-ignore: Async components are valid in the app directory
+export default function Page() {
   return <Post />
 }

--- a/apps/test-app/app/light/suspense/[tweet]/page.tsx
+++ b/apps/test-app/app/light/suspense/[tweet]/page.tsx
@@ -4,7 +4,7 @@ import TweetPage from './tweet-page'
 
 export const revalidate = 60
 
-export default async function Page({ params }: { params: { tweet: string } }) {
+export default function Page({ params }: { params: { tweet: string } }) {
   // TODO: Figure out why Next.js sends this value at build time
   if (params.tweet === '%5Btweet%5D') return null
   return (

--- a/packages/next-tweet/readme.md
+++ b/packages/next-tweet/readme.md
@@ -44,7 +44,6 @@ In any component, import `NextTweet` from `next-tweet` and use it like so:
 import { NextTweet } from 'next-tweet'
 
 export default function Page({ params }: Props) {
-  // @ts-ignore: Async components are valid in the app directory
   return <NextTweet id={params.tweet} />
 }
 ```

--- a/packages/next-tweet/src/tweet.tsx
+++ b/packages/next-tweet/src/tweet.tsx
@@ -24,7 +24,7 @@ const Tweet = async ({ id, priority = false, notFoundOnError }: TweetProps) => {
   return <EmbeddedTweet tweet={tweet} priority={priority} />
 }
 
-export const NextTweet = async ({
+export const NextTweet = ({
   fallback = <TweetSkeleton />,
   ...props
 }: Props) => (


### PR DESCRIPTION
This commit enhances the developer experience since `NextTweet` component no longer needs a `ts-ignore` (or similar) comment, as the component itself is no longer `async`.

Functionally it should still work normally. I have done some manual tests on all `test-app` pages, but you might want to test it too.

Although if this PR is merged, it will (I think) break the build for anyone using `ts-expect-error` instead of `ts-ignore`. But we are in v0.x.x here so I think a minor version bump is fine...