### PR TITLE
Use provided image `alt` text if user added one

### DIFF
--- a/packages/next-tweet/src/api/types/media.ts
+++ b/packages/next-tweet/src/api/types/media.ts
@@ -58,6 +58,7 @@ interface MediaBase {
 
 export interface MediaPhoto extends MediaBase {
   type: 'photo'
+  ext_alt_text?: string
 }
 
 export interface MediaAnimatedGif extends MediaBase {

--- a/packages/next-tweet/src/tweet-media.tsx
+++ b/packages/next-tweet/src/tweet-media.tsx
@@ -32,12 +32,11 @@ export const TweetMedia = ({ tweet, priority = false }: Props) => {
               className={clsx(s.mediaContainer, s.mediaLink)}
               target="_blank"
               rel="noopener noreferrer"
-              aria-label={media.type === 'photo' ? 'Image' : 'Embedded Video'}
             >
               <Image
                 src={getMediaUrl(media, 'small')}
                 className={s.image}
-                alt={media.type === 'photo' ? 'Image' : 'Embedded Video'}
+                alt={media.ext_alt_text || 'Image'}
                 fill
                 draggable
                 unoptimized


### PR DESCRIPTION
Twitter allows users to add `alt` text to their images when adding them to a tweet. The API also exposes this to us for photo media types. We should use that user-provided alt test as descriptive text on the `img` if provided.

Additionally, since the `<Image />` is the only descendant of the containing `<a>`, an `aria-label` on the anchor is duplicative. A screen reader will use the `img` alt tag as the anchor text. Removing the `aria-label` attribute will keep a screen reader from reading out the same text twice in row.

[Example tweet](https://twitter.com/CaseyNewton/status/1632849093897891840) where alt text is provided