### PR TITLE
fix: set `isLoading: false` when id is `undefined`

### DIFF
--- a/packages/react-tweet/src/hooks.ts
+++ b/packages/react-tweet/src/hooks.ts
@@ -48,9 +48,11 @@ export const useTweet = (
   )
 
   return {
-    // If data is `undefined` then it might be the first render where SWR hasn't started doing
+    // If id is provided but data is `undefined` then it might be the first render where SWR hasn't started doing
     // any work, so we set `isLoading` to `true`.
-    isLoading: Boolean(isLoading || (data === undefined && !error)),
+    isLoading: Boolean(
+      isLoading || (id !== undefined && data === undefined && !error)
+    ),
     data,
     error,
   }


### PR DESCRIPTION
I can't tell if this PR is a `fix` or a `feat`.

---

If `id` is  `undefined`, `useTweet` return `isLoading: true`. However, I think `useTweet` should return `isLoading: false` because SWR cannot without id. For this reason, I propose to change a behavior of `useTweet`.

If this change is reasonable, a behavior of `<Tweet />` may also need to be changed.

https://github.com/vercel/react-tweet/blob/main/packages/react-tweet/src/swr.tsx