### PR TITLE
fix: empty object tweet

### DIFF
--- a/packages/react-tweet/src/api/fetch-tweet.ts
+++ b/packages/react-tweet/src/api/fetch-tweet.ts
@@ -74,7 +74,7 @@ export async function fetchTweet(
     if (data?.__typename === 'TweetTombstone') {
       return { tombstone: true }
     }
-    if (Object.keys(data).length === 0) {
+    if (data && Object.keys(data).length === 0) {
       return { notFound: true }
     }
     return { data }


### PR DESCRIPTION
API response for tweet `0` returns an empty object, not sure if there are other cases.
https://react-tweet.vercel.app/api/tweet/0

This breaks code as the type and checks for data does not match this.