### PR TITLE
fix: handle missing entity fields from X syndication API

### DIFF
--- a/packages/react-tweet/src/utils.ts
+++ b/packages/react-tweet/src/utils.ts
@@ -122,10 +122,10 @@ function getEntities(tweet: TweetBase): Entity[] {
     { indices: tweet.display_text_range, type: 'text' },
   ]
 
-  addEntities(result, 'hashtag', tweet.entities.hashtags)
-  addEntities(result, 'mention', tweet.entities.user_mentions)
-  addEntities(result, 'url', tweet.entities.urls)
-  addEntities(result, 'symbol', tweet.entities.symbols)
+  addEntities(result, 'hashtag', tweet.entities.hashtags ?? [])
+  addEntities(result, 'mention', tweet.entities.user_mentions ?? [])
+  addEntities(result, 'url', tweet.entities.urls ?? [])
+  addEntities(result, 'symbol', tweet.entities.symbols ?? [])
   if (tweet.entities.media) {
     addEntities(result, 'media', tweet.entities.media)
   }
@@ -158,7 +158,7 @@ function getEntities(tweet: TweetBase): Entity[] {
 function addEntities(
   result: EntityWithType[],
   type: EntityWithType['type'],
-  entities: TweetEntity[]
+  entities: TweetEntity[] = []
 ) {
   for (const entity of entities) {
     for (const [i, item] of result.entries()) {


### PR DESCRIPTION
## Problem

The X syndication API omits `entities.hashtags`, `.user_mentions`, `.urls`, and `.symbols` when a tweet has none of those entities, instead of returning empty arrays. This causes `getEntities()` to pass `undefined` to `addEntities()`, which crashes with:

```
TypeError: entities is not iterable
```

This affects any tweet that has no hashtags, mentions, URLs, or symbols (e.g. text + image only tweets).

Example tweet that reproduces the issue: https://x.com/RiotPhroxzon/status/2056998824779079835

Response from the syndication API for this tweet:
```json
"entities": {
  "media": [{ ... }]
}
```

Note the absence of `hashtags`, `user_mentions`, `urls`, and `symbols` fields.

## Fix

- Add `?? []` fallback when passing entity arrays to `addEntities()` in `getEntities()`
- Add default parameter value `entities: TweetEntity[] = []` in `addEntities()` as an additional safety net

Fixes #218